### PR TITLE
feat: implement docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/artemstepanov/caddy-orchestrator-lite
+          tags: |
+            type=ref,event=branch
+            type=sha,format=short
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ dist/
 # Temporary files
 tmp/
 temp/
+
+# Docker
+docker-compose.override.yml

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build run dev docker clean test
+.PHONY: all build run dev docker clean test docker-up-build
 
 # Build all
 all: build
@@ -25,7 +25,11 @@ docker:
 
 # Run with Docker Compose
 docker-up:
-	docker compose up -d --build
+	docker compose up -d
+
+# Run with Docker Compose (local build)
+docker-up-build:
+	docker build -t ghcr.io/artemstepanov/caddy-orchestrator-lite:latest . && docker compose up -d
 
 # Stop Docker Compose
 docker-down:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
 services:
   # Caddy Orchestrator Lite
   orchestrator:
-    build: .
+    image: ghcr.io/artemstepanov/caddy-orchestrator-lite:latest
+    # build: .  # uncomment for local development
     ports:
       - "3000:3000"
     environment:


### PR DESCRIPTION
feat: Automate Docker image releases to GHCR via GitHub Actions and update local Docker Compose setup to use pre-built images with a dedicated local build target.

## Description

implement docker image.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring

## Related Issues

## Testing

- [x] Tests pass locally
- [x] Manual testing completed