### PR TITLE
fix: detect handler types for Caddyfile subroute configs

### DIFF
--- a/internal/config/builder.go
+++ b/internal/config/builder.go
@@ -303,35 +303,52 @@ func buildRouteMerged(r *storage.Route, global *storage.GlobalConfig) *Route {
 	// If we find an unknown handler, we add it.
 	// We inject our Main Handler at the first position where a "managed" handler was, or at end.
 
-	var unknownHandlers []Handler
-	managedTypes := map[string]bool{
-		"reverse_proxy":   true,
-		"file_server":     true,
-		"static_response": true, // could be redir or something else, but we treat it as managed if we are in redir mode
-		"headers":         true,
-		"encode":          true,
-		"rewrite":         true,
-	}
-
+	// Check if the original route uses subroute wrappers (Caddyfile-generated).
+	// If so, preserve the entire original handler chain — the main handler lives
+	// inside the subroute alongside middleware we can't represent (crowdsec, etc.),
+	// so rebuilding from scratch would lose those handlers.
+	hasSubroute := false
 	for _, h := range original.Handle {
-		hType, _ := h["handler"].(string)
-		if !managedTypes[hType] {
-			unknownHandlers = append(unknownHandlers, h)
+		if hType, _ := h["handler"].(string); hType == "subroute" {
+			hasSubroute = true
+			break
 		}
 	}
 
-	// Now construct final list:
-	// [encode] + [headers] + [unknowns] + [mainHandler]
-	// This puts unknown middlewares before the final handler (reverse_proxy is terminal usually).
-	// If unknown handler is a terminal one (like `acme_server`), it might conflict if we also add reverse_proxy.
-	// But usually we only have one terminal handler.
+	if hasSubroute {
+		// Preserve original handlers as-is; only matchers were updated above.
+		// Skip rebuilding handlers to avoid duplicating or losing nested handlers.
+		// Note: this means handler-level edits (upstreams, headers) on subroute-imported
+		// routes won't take effect on export. This is acceptable because these routes
+		// were previously undetectable ("unknown") and contain middleware (crowdsec, etc.)
+		// that we can't represent. Full edit support would require walking into the
+		// subroute to replace managed handlers in-place.
+	} else {
+		var unknownHandlers []Handler
+		managedTypes := map[string]bool{
+			"reverse_proxy":   true,
+			"file_server":     true,
+			"static_response": true,
+			"headers":         true,
+			"encode":          true,
+			"rewrite":         true,
+		}
 
-	newHandlers = append(newHandlers, unknownHandlers...)
-	if mainHandler != nil {
-		newHandlers = append(newHandlers, mainHandler)
+		for _, h := range original.Handle {
+			hType, _ := h["handler"].(string)
+			if !managedTypes[hType] {
+				unknownHandlers = append(unknownHandlers, h)
+			}
+		}
+
+		newHandlers = append(newHandlers, unknownHandlers...)
+		if mainHandler != nil {
+			newHandlers = append(newHandlers, mainHandler)
+		}
+
+		original.Handle = newHandlers
 	}
 
-	original.Handle = newHandlers
 	original.Terminal = true
 
 	return &original

--- a/internal/config/builder.go
+++ b/internal/config/builder.go
@@ -63,6 +63,16 @@ type Match struct {
 // Handler is a generic handler
 type Handler map[string]any
 
+// managedHandlerTypes lists handler types that our model can fully represent and rebuild.
+var managedHandlerTypes = map[string]bool{
+	"reverse_proxy":   true,
+	"file_server":     true,
+	"static_response": true,
+	"headers":         true,
+	"encode":          true,
+	"rewrite":         true,
+}
+
 // BuildCaddyConfig converts stored routes to Caddy JSON config
 func BuildCaddyConfig(routes []*storage.Route, global *storage.GlobalConfig) *CaddyConfig {
 	// Always preserve admin listener on 0.0.0.0:2019 so we can continue managing Caddy
@@ -315,28 +325,13 @@ func buildRouteMerged(r *storage.Route, global *storage.GlobalConfig) *Route {
 		}
 	}
 
-	if hasSubroute {
-		// Preserve original handlers as-is; only matchers were updated above.
-		// Skip rebuilding handlers to avoid duplicating or losing nested handlers.
-		// Note: this means handler-level edits (upstreams, headers) on subroute-imported
-		// routes won't take effect on export. This is acceptable because these routes
-		// were previously undetectable ("unknown") and contain middleware (crowdsec, etc.)
-		// that we can't represent. Full edit support would require walking into the
-		// subroute to replace managed handlers in-place.
-	} else {
+	if !hasSubroute {
+		// Non-subroute route: rebuild handlers by replacing managed types with ours
+		// and preserving unknown handlers.
 		var unknownHandlers []Handler
-		managedTypes := map[string]bool{
-			"reverse_proxy":   true,
-			"file_server":     true,
-			"static_response": true,
-			"headers":         true,
-			"encode":          true,
-			"rewrite":         true,
-		}
-
 		for _, h := range original.Handle {
 			hType, _ := h["handler"].(string)
-			if !managedTypes[hType] {
+			if !managedHandlerTypes[hType] {
 				unknownHandlers = append(unknownHandlers, h)
 			}
 		}
@@ -348,6 +343,10 @@ func buildRouteMerged(r *storage.Route, global *storage.GlobalConfig) *Route {
 
 		original.Handle = newHandlers
 	}
+	// else: subroute route — preserve original handlers as-is. Only matchers
+	// were updated above. Handler-level edits won't take effect on export,
+	// which is acceptable because these routes contain middleware (crowdsec, etc.)
+	// that we can't represent.
 
 	original.Terminal = true
 

--- a/internal/config/parser.go
+++ b/internal/config/parser.go
@@ -70,9 +70,13 @@ func parseRoute(r Route) (*storage.Route, error) {
 	// We look for known handlers: reverse_proxy, file_server, static_response (redir)
 	// We also look for headers and encode
 
+	// Collect all handlers, unwrapping subroutes so we can find the actual handlers
+	// Caddy wraps handlers in "subroute" when configured via Caddyfile
+	allHandlers := flattenHandlers(r.Handle)
+
 	var mainHandlerFound bool
 
-	for _, h := range r.Handle {
+	for _, h := range allHandlers {
 		handlerType, ok := h["handler"].(string)
 		if !ok {
 			continue
@@ -140,14 +144,177 @@ func parseRoute(r Route) (*storage.Route, error) {
 		}
 	}
 
-	if !mainHandlerFound {
-		// If we couldn't parse a known main handler, mark as unknown
+	if mainHandlerFound {
+		// If we successfully extracted all handlers via flatten, check whether
+		// the route can be fully rebuilt from our model (all handlers are managed).
+		// If so, clear RawCaddyRoute so the route goes through normal buildRoute
+		// (editable) instead of buildRouteMerged (read-only preservation).
+		if allHandlersManaged(allHandlers) {
+			storageRoute.RawCaddyRoute = nil
+		}
+	} else {
+		// Flattening didn't work (complex subroute). Do a deep search through
+		// the entire handler tree to at least identify the handler type for display.
 		// The original JSON is preserved in RawCaddyRoute, so it will be synced back as is.
-		storageRoute.HandlerType = "unknown"
+		if detected := detectDeepHandlerType(r.Handle); detected != "" {
+			// Normalize: Caddy uses "static_response" but our model uses "redir"
+			if detected == "static_response" {
+				detected = "redir"
+			}
+			storageRoute.HandlerType = detected
+		} else {
+			storageRoute.HandlerType = "unknown"
+		}
 		storageRoute.Config = json.RawMessage("{}")
 	}
 
 	return storageRoute, nil
+}
+
+// flattenHandlers unwraps simple subroute handlers to extract the actual handlers within.
+// Caddy wraps handlers in "subroute" when configured via Caddyfile.
+// Only unwraps subroutes whose inner routes have no matchers (simple wrappers).
+// Subroutes with nested matchers (e.g. from handle_path) are left as-is to avoid
+// losing routing semantics.
+func flattenHandlers(handlers []Handler) []Handler {
+	var result []Handler
+	for _, h := range handlers {
+		handlerType, _ := h["handler"].(string)
+		if handlerType == "subroute" {
+			if nested := extractSimpleSubrouteHandlers(h); nested != nil {
+				result = append(result, nested...)
+				continue
+			}
+		}
+		result = append(result, h)
+	}
+	return result
+}
+
+// extractSimpleSubrouteHandlers extracts handlers from a subroute only if it
+// contains exactly one inner route with no match conditions and no terminal flag.
+// This covers the common Caddyfile pattern where handlers are wrapped in a trivial
+// subroute. Returns nil for complex subroutes (multiple routes, matchers, terminal).
+//
+// Note: this is used for type DETECTION only. The original structure is preserved
+// in RawCaddyRoute. Unrecognized handlers (crowdsec, appsec, etc.) are extracted
+// here but simply ignored by the caller's switch statement.
+func extractSimpleSubrouteHandlers(h Handler) []Handler {
+	routes, ok := h["routes"].([]any)
+	if !ok || len(routes) != 1 {
+		return nil
+	}
+
+	routeMap, ok := routes[0].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	// If the inner route has matchers, this is a complex subroute — don't flatten
+	if match, hasMatch := routeMap["match"]; hasMatch {
+		if matchSlice, ok := match.([]any); ok && len(matchSlice) > 0 {
+			return nil
+		}
+	}
+
+	// If the inner route has terminal flag, don't flatten (route-level flow control)
+	if terminal, ok := routeMap["terminal"].(bool); ok && terminal {
+		return nil
+	}
+
+	nestedHandlers, ok := routeMap["handle"].([]any)
+	if !ok {
+		return nil
+	}
+
+	var result []Handler
+	for _, nh := range nestedHandlers {
+		if nhMap, ok := nh.(map[string]any); ok {
+			// Recursively flatten in case of nested subroutes
+			result = append(result, flattenHandlers([]Handler{nhMap})...)
+		}
+	}
+	return result
+}
+
+// allHandlersManaged returns true if every handler in the list is a type
+// we can fully represent and rebuild in our model.
+func allHandlersManaged(handlers []Handler) bool {
+	managed := map[string]bool{
+		"reverse_proxy":   true,
+		"file_server":     true,
+		"static_response": true,
+		"headers":         true,
+		"encode":          true,
+		"rewrite":         true,
+	}
+	for _, h := range handlers {
+		hType, _ := h["handler"].(string)
+		if !managed[hType] {
+			return false
+		}
+	}
+	return true
+}
+
+// detectDeepHandlerType recursively searches through all handlers (including
+// nested subroutes) to find a main handler type. Used as a fallback when
+// flattenHandlers can't extract handlers from complex subroute structures.
+// Prioritizes reverse_proxy and file_server over static_response, since
+// static_response is often used as auxiliary middleware (e.g. websocket blocking).
+func detectDeepHandlerType(handlers []Handler) string {
+	var found []string
+	collectDeepHandlerTypes(handlers, &found)
+
+	// Prefer reverse_proxy > file_server > static_response
+	for _, t := range found {
+		if t == "reverse_proxy" {
+			return t
+		}
+	}
+	for _, t := range found {
+		if t == "file_server" {
+			return t
+		}
+	}
+	for _, t := range found {
+		if t == "static_response" {
+			return t
+		}
+	}
+	return ""
+}
+
+func collectDeepHandlerTypes(handlers []Handler, found *[]string) {
+	mainTypes := map[string]bool{
+		"reverse_proxy":   true,
+		"file_server":     true,
+		"static_response": true,
+	}
+
+	for _, h := range handlers {
+		hType, _ := h["handler"].(string)
+		if mainTypes[hType] {
+			*found = append(*found, hType)
+		}
+		if hType == "subroute" {
+			if routes, ok := h["routes"].([]any); ok {
+				for _, r := range routes {
+					if routeMap, ok := r.(map[string]any); ok {
+						if nested, ok := routeMap["handle"].([]any); ok {
+							var nestedHandlers []Handler
+							for _, nh := range nested {
+								if nhMap, ok := nh.(map[string]any); ok {
+									nestedHandlers = append(nestedHandlers, nhMap)
+								}
+							}
+							collectDeepHandlerTypes(nestedHandlers, found)
+						}
+					}
+				}
+			}
+		}
+	}
 }
 
 func createRawRoute(r Route) *storage.Route {

--- a/internal/config/parser.go
+++ b/internal/config/parser.go
@@ -108,19 +108,17 @@ func parseRoute(r Route) (*storage.Route, error) {
 			}
 
 		case "static_response":
-			// Check if it's a redirect (has Location header)
-			if headers, ok := h["headers"].(map[string]any); ok {
-				if _, hasLoc := headers["Location"]; hasLoc {
-					if mainHandlerFound {
-						continue
-					}
+			// Only treat as redirect if it has a Location header
+			if isRedirectStaticResponse(h) {
+				if mainHandlerFound {
+					continue
+				}
 
-					cfg, err := parseRedirect(h)
-					if err == nil {
-						storageRoute.HandlerType = "redir"
-						storageRoute.Config, _ = json.Marshal(cfg)
-						mainHandlerFound = true
-					}
+				cfg, err := parseRedirect(h)
+				if err == nil {
+					storageRoute.HandlerType = "redir"
+					storageRoute.Config, _ = json.Marshal(cfg)
+					mainHandlerFound = true
 				}
 			}
 
@@ -151,21 +149,23 @@ func parseRoute(r Route) (*storage.Route, error) {
 		// (editable) instead of buildRouteMerged (read-only preservation).
 		if allHandlersManaged(allHandlers) {
 			storageRoute.RawCaddyRoute = nil
+		} else {
+			// Route has unmanaged middleware (e.g. crowdsec) — type is detected but
+			// handler-level edits won't propagate on export since we preserve the
+			// original subroute structure. Mark as read-only so the UI can indicate this.
+			storageRoute.ReadOnly = true
 		}
 	} else {
 		// Flattening didn't work (complex subroute). Do a deep search through
 		// the entire handler tree to at least identify the handler type for display.
 		// The original JSON is preserved in RawCaddyRoute, so it will be synced back as is.
 		if detected := detectDeepHandlerType(r.Handle); detected != "" {
-			// Normalize: Caddy uses "static_response" but our model uses "redir"
-			if detected == "static_response" {
-				detected = "redir"
-			}
 			storageRoute.HandlerType = detected
 		} else {
 			storageRoute.HandlerType = "unknown"
 		}
 		storageRoute.Config = json.RawMessage("{}")
+		storageRoute.ReadOnly = true
 	}
 
 	return storageRoute, nil
@@ -240,17 +240,9 @@ func extractSimpleSubrouteHandlers(h Handler) []Handler {
 // allHandlersManaged returns true if every handler in the list is a type
 // we can fully represent and rebuild in our model.
 func allHandlersManaged(handlers []Handler) bool {
-	managed := map[string]bool{
-		"reverse_proxy":   true,
-		"file_server":     true,
-		"static_response": true,
-		"headers":         true,
-		"encode":          true,
-		"rewrite":         true,
-	}
 	for _, h := range handlers {
 		hType, _ := h["handler"].(string)
-		if !managed[hType] {
+		if !managedHandlerTypes[hType] {
 			return false
 		}
 	}
@@ -260,13 +252,14 @@ func allHandlersManaged(handlers []Handler) bool {
 // detectDeepHandlerType recursively searches through all handlers (including
 // nested subroutes) to find a main handler type. Used as a fallback when
 // flattenHandlers can't extract handlers from complex subroute structures.
-// Prioritizes reverse_proxy and file_server over static_response, since
-// static_response is often used as auxiliary middleware (e.g. websocket blocking).
+// Prioritizes reverse_proxy and file_server over static_response (redirect only),
+// since static_response is often used as auxiliary middleware (e.g. websocket blocking).
+// Only static_response handlers with a Location header are treated as redirects.
 func detectDeepHandlerType(handlers []Handler) string {
 	var found []string
 	collectDeepHandlerTypes(handlers, &found)
 
-	// Prefer reverse_proxy > file_server > static_response
+	// Prefer reverse_proxy > file_server > redir (redirect static_response)
 	for _, t := range found {
 		if t == "reverse_proxy" {
 			return t
@@ -278,7 +271,7 @@ func detectDeepHandlerType(handlers []Handler) string {
 		}
 	}
 	for _, t := range found {
-		if t == "static_response" {
+		if t == "redir" {
 			return t
 		}
 	}
@@ -286,18 +279,17 @@ func detectDeepHandlerType(handlers []Handler) string {
 }
 
 func collectDeepHandlerTypes(handlers []Handler, found *[]string) {
-	mainTypes := map[string]bool{
-		"reverse_proxy":   true,
-		"file_server":     true,
-		"static_response": true,
-	}
-
 	for _, h := range handlers {
 		hType, _ := h["handler"].(string)
-		if mainTypes[hType] {
+		switch hType {
+		case "reverse_proxy", "file_server":
 			*found = append(*found, hType)
-		}
-		if hType == "subroute" {
+		case "static_response":
+			// Only treat as redirect if it has a Location header
+			if isRedirectStaticResponse(h) {
+				*found = append(*found, "redir")
+			}
+		case "subroute":
 			if routes, ok := h["routes"].([]any); ok {
 				for _, r := range routes {
 					if routeMap, ok := r.(map[string]any); ok {
@@ -315,6 +307,17 @@ func collectDeepHandlerTypes(handlers []Handler, found *[]string) {
 			}
 		}
 	}
+}
+
+// isRedirectStaticResponse checks whether a static_response handler is a redirect
+// by looking for a Location header.
+func isRedirectStaticResponse(h Handler) bool {
+	headers, ok := h["headers"].(map[string]any)
+	if !ok {
+		return false
+	}
+	_, hasLocation := headers["Location"]
+	return hasLocation
 }
 
 func createRawRoute(r Route) *storage.Route {

--- a/internal/config/parser_test.go
+++ b/internal/config/parser_test.go
@@ -550,3 +550,730 @@ func TestRoundTrip_StripPathPrefix(t *testing.T) {
 		t.Errorf("Expected path /api/*, got %s", parsed.Path)
 	}
 }
+
+func TestParseCaddyConfig_SubrouteReverseProxy(t *testing.T) {
+	// This is how Caddy generates config from Caddyfile — handlers are wrapped in subroute
+	cfg := &CaddyConfig{
+		Apps: &Apps{
+			HTTP: &HTTPApp{
+				Servers: map[string]*Server{
+					"srv0": {
+						Listen: []string{":443"},
+						Routes: []Route{
+							{
+								Match: []Match{
+									{Host: []string{"example.com"}},
+								},
+								Handle: []Handler{
+									{
+										"handler": "subroute",
+										"routes": []any{
+											map[string]any{
+												"handle": []any{
+													map[string]any{
+														"handler": "reverse_proxy",
+														"upstreams": []any{
+															map[string]any{"dial": "localhost:8080"},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								Terminal: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	routes, err := ParseCaddyConfig(cfg)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if len(routes) != 1 {
+		t.Fatalf("Expected 1 route, got %d", len(routes))
+	}
+
+	route := routes[0]
+	if route.Domain != "example.com" {
+		t.Errorf("Expected domain example.com, got %s", route.Domain)
+	}
+	if route.HandlerType != "reverse_proxy" {
+		t.Errorf("Expected handler_type reverse_proxy, got %s", route.HandlerType)
+	}
+
+	var rpCfg storage.ReverseProxyConfig
+	json.Unmarshal(route.Config, &rpCfg)
+	if len(rpCfg.Upstreams) != 1 || rpCfg.Upstreams[0] != "localhost:8080" {
+		t.Errorf("Expected upstreams [localhost:8080], got %v", rpCfg.Upstreams)
+	}
+}
+
+func TestParseCaddyConfig_SubrouteWithHeaders(t *testing.T) {
+	// Subroute containing both headers and reverse_proxy handlers
+	cfg := &CaddyConfig{
+		Apps: &Apps{
+			HTTP: &HTTPApp{
+				Servers: map[string]*Server{
+					"srv0": {
+						Listen: []string{":443"},
+						Routes: []Route{
+							{
+								Match: []Match{
+									{Host: []string{"example.com"}},
+								},
+								Handle: []Handler{
+									{
+										"handler": "subroute",
+										"routes": []any{
+											map[string]any{
+												"handle": []any{
+													map[string]any{
+														"handler": "headers",
+														"response": map[string]any{
+															"set": map[string]any{
+																"X-Frame-Options": []any{"DENY"},
+															},
+														},
+													},
+													map[string]any{
+														"handler": "reverse_proxy",
+														"upstreams": []any{
+															map[string]any{"dial": "localhost:9000"},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								Terminal: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	routes, err := ParseCaddyConfig(cfg)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	route := routes[0]
+	if route.HandlerType != "reverse_proxy" {
+		t.Errorf("Expected handler_type reverse_proxy, got %s", route.HandlerType)
+	}
+	if route.Headers == nil {
+		t.Fatal("Expected headers to be parsed")
+	}
+	if route.Headers.Set["X-Frame-Options"] != "DENY" {
+		t.Errorf("Expected Set X-Frame-Options=DENY, got %v", route.Headers.Set)
+	}
+}
+
+func TestParseCaddyConfig_SubrouteFromJSON(t *testing.T) {
+	// Simulate actual Caddy API JSON response (as returned by Caddyfile-configured instances)
+	raw := []byte(`{
+		"apps": {
+			"http": {
+				"servers": {
+					"srv0": {
+						"listen": [":443"],
+						"routes": [
+							{
+								"match": [{"host": ["app.example.com"]}],
+								"handle": [{
+									"handler": "subroute",
+									"routes": [{
+										"handle": [{
+											"handler": "reverse_proxy",
+											"upstreams": [{"dial": "localhost:3000"}]
+										}]
+									}]
+								}],
+								"terminal": true
+							}
+						]
+					}
+				}
+			}
+		}
+	}`)
+
+	var cfg CaddyConfig
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("Failed to unmarshal: %v", err)
+	}
+
+	routes, err := ParseCaddyConfig(&cfg)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if len(routes) != 1 {
+		t.Fatalf("Expected 1 route, got %d", len(routes))
+	}
+
+	route := routes[0]
+	if route.HandlerType != "reverse_proxy" {
+		t.Errorf("Expected handler_type reverse_proxy, got %s", route.HandlerType)
+	}
+	if route.Domain != "app.example.com" {
+		t.Errorf("Expected domain app.example.com, got %s", route.Domain)
+	}
+}
+
+func TestParseCaddyConfig_RealCaddyfileStructure(t *testing.T) {
+	// Real Caddy config from Caddyfile: nested subroutes with crowdsec + appsec + reverse_proxy
+	raw := []byte(`{
+		"apps": {
+			"http": {
+				"servers": {
+					"srv0": {
+						"listen": [":443"],
+						"routes": [
+							{
+								"match": [{"host": ["app.example.com"]}],
+								"handle": [{
+									"handler": "subroute",
+									"routes": [{
+										"handle": [{
+											"handler": "subroute",
+											"routes": [{
+												"handle": [
+													{"handler": "crowdsec"},
+													{"handler": "appsec"},
+													{
+														"handler": "reverse_proxy",
+														"headers": {
+															"request": {
+																"set": {
+																	"X-Forwarded-For": ["{http.vars.client_ip}"],
+																	"X-Real-Ip": ["{http.vars.client_ip}"]
+																}
+															}
+														},
+														"upstreams": [{"dial": "docker-hp:2111"}]
+													}
+												]
+											}]
+										}]
+									}]
+								}],
+								"terminal": true
+							}
+						]
+					}
+				}
+			}
+		}
+	}`)
+
+	var cfg CaddyConfig
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("Failed to unmarshal: %v", err)
+	}
+
+	routes, err := ParseCaddyConfig(&cfg)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	route := routes[0]
+	if route.Domain != "app.example.com" {
+		t.Errorf("Expected domain app.example.com, got %s", route.Domain)
+	}
+	if route.HandlerType != "reverse_proxy" {
+		t.Errorf("Expected handler_type reverse_proxy, got %s", route.HandlerType)
+	}
+
+	var rpCfg storage.ReverseProxyConfig
+	json.Unmarshal(route.Config, &rpCfg)
+	if len(rpCfg.Upstreams) != 1 || rpCfg.Upstreams[0] != "docker-hp:2111" {
+		t.Errorf("Expected upstreams [docker-hp:2111], got %v", rpCfg.Upstreams)
+	}
+}
+
+func TestParseCaddyConfig_NestedSubroutes(t *testing.T) {
+	// Subroute inside subroute (both without matchers)
+	cfg := &CaddyConfig{
+		Apps: &Apps{
+			HTTP: &HTTPApp{
+				Servers: map[string]*Server{
+					"srv0": {
+						Listen: []string{":443"},
+						Routes: []Route{
+							{
+								Match: []Match{
+									{Host: []string{"example.com"}},
+								},
+								Handle: []Handler{
+									{
+										"handler": "subroute",
+										"routes": []any{
+											map[string]any{
+												"handle": []any{
+													map[string]any{
+														"handler": "subroute",
+														"routes": []any{
+															map[string]any{
+																"handle": []any{
+																	map[string]any{
+																		"handler": "file_server",
+																		"root":    "/srv",
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								Terminal: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	routes, err := ParseCaddyConfig(cfg)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	route := routes[0]
+	if route.HandlerType != "file_server" {
+		t.Errorf("Expected handler_type file_server, got %s", route.HandlerType)
+	}
+}
+
+func TestParseCaddyConfig_SubrouteWithMatchers(t *testing.T) {
+	// Subroute with nested matchers (e.g. from handle_path) should stay "unknown"
+	// to avoid losing routing semantics
+	cfg := &CaddyConfig{
+		Apps: &Apps{
+			HTTP: &HTTPApp{
+				Servers: map[string]*Server{
+					"srv0": {
+						Listen: []string{":443"},
+						Routes: []Route{
+							{
+								Match: []Match{
+									{Host: []string{"example.com"}},
+								},
+								Handle: []Handler{
+									{
+										"handler": "subroute",
+										"routes": []any{
+											map[string]any{
+												"match": []any{
+													map[string]any{
+														"path": []any{"/api/*"},
+													},
+												},
+												"handle": []any{
+													map[string]any{
+														"handler": "reverse_proxy",
+														"upstreams": []any{
+															map[string]any{"dial": "localhost:8080"},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								Terminal: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	routes, err := ParseCaddyConfig(cfg)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	route := routes[0]
+	// Deep detection should find reverse_proxy even inside complex subroute
+	if route.HandlerType != "reverse_proxy" {
+		t.Errorf("Expected handler_type reverse_proxy (deep detected), got %s", route.HandlerType)
+	}
+	// Raw route should be preserved
+	if len(route.RawCaddyRoute) == 0 {
+		t.Error("Expected RawCaddyRoute to be preserved")
+	}
+}
+
+func TestParseCaddyConfig_SubrouteWithUnmanagedHandler(t *testing.T) {
+	// Subroute containing unmanaged handlers (crowdsec, appsec) alongside reverse_proxy.
+	// Should detect reverse_proxy type — unmanaged handlers are preserved in RawCaddyRoute.
+	cfg := &CaddyConfig{
+		Apps: &Apps{
+			HTTP: &HTTPApp{
+				Servers: map[string]*Server{
+					"srv0": {
+						Listen: []string{":443"},
+						Routes: []Route{
+							{
+								Match: []Match{
+									{Host: []string{"example.com"}},
+								},
+								Handle: []Handler{
+									{
+										"handler": "subroute",
+										"routes": []any{
+											map[string]any{
+												"handle": []any{
+													map[string]any{
+														"handler": "crowdsec",
+													},
+													map[string]any{
+														"handler": "reverse_proxy",
+														"upstreams": []any{
+															map[string]any{"dial": "localhost:8080"},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								Terminal: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	routes, err := ParseCaddyConfig(cfg)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	route := routes[0]
+	if route.HandlerType != "reverse_proxy" {
+		t.Errorf("Expected handler_type reverse_proxy, got %s", route.HandlerType)
+	}
+	// RawCaddyRoute should preserve the full original including crowdsec
+	if len(route.RawCaddyRoute) == 0 {
+		t.Error("Expected RawCaddyRoute to be preserved")
+	}
+}
+
+func TestParseCaddyConfig_MultiRouteSubroute(t *testing.T) {
+	// Subroute with multiple inner routes should stay "unknown" even without matchers
+	// because route boundaries and terminal flags change Caddy's behavior
+	cfg := &CaddyConfig{
+		Apps: &Apps{
+			HTTP: &HTTPApp{
+				Servers: map[string]*Server{
+					"srv0": {
+						Listen: []string{":443"},
+						Routes: []Route{
+							{
+								Match: []Match{
+									{Host: []string{"example.com"}},
+								},
+								Handle: []Handler{
+									{
+										"handler": "subroute",
+										"routes": []any{
+											map[string]any{
+												"handle": []any{
+													map[string]any{
+														"handler": "reverse_proxy",
+														"upstreams": []any{
+															map[string]any{"dial": "localhost:8080"},
+														},
+													},
+												},
+											},
+											map[string]any{
+												"handle": []any{
+													map[string]any{
+														"handler": "headers",
+														"response": map[string]any{
+															"set": map[string]any{
+																"X-Debug": []any{"true"},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								Terminal: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	routes, err := ParseCaddyConfig(cfg)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	route := routes[0]
+	// Deep detection should find reverse_proxy even in multi-route subroute
+	if route.HandlerType != "reverse_proxy" {
+		t.Errorf("Expected handler_type reverse_proxy (deep detected), got %s", route.HandlerType)
+	}
+}
+
+func TestRoundTrip_UnknownSubroutePreserved(t *testing.T) {
+	// Complex subroute (with matchers) should be preserved as-is on round-trip
+	raw := []byte(`{
+		"apps": {
+			"http": {
+				"servers": {
+					"srv0": {
+						"listen": [":443"],
+						"routes": [
+							{
+								"match": [{"host": ["example.com"]}],
+								"handle": [{
+									"handler": "subroute",
+									"routes": [
+										{
+											"match": [{"path": ["/api/*"]}],
+											"handle": [{
+												"handler": "reverse_proxy",
+												"upstreams": [{"dial": "localhost:8080"}]
+											}]
+										}
+									]
+								}],
+								"terminal": true
+							}
+						]
+					}
+				}
+			}
+		}
+	}`)
+
+	var cfg CaddyConfig
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("Failed to unmarshal: %v", err)
+	}
+
+	// Import — should detect reverse_proxy via deep search despite nested matchers
+	routes, err := ParseCaddyConfig(&cfg)
+	if err != nil {
+		t.Fatalf("Failed to parse: %v", err)
+	}
+	imported := routes[0]
+	if imported.HandlerType != "reverse_proxy" {
+		t.Fatalf("Expected reverse_proxy, got %s", imported.HandlerType)
+	}
+
+	// Export — should preserve the subroute handler (not strip it)
+	exportedConfig := BuildCaddyConfig(routes, nil)
+
+	exportedJSON, err := json.Marshal(exportedConfig)
+	if err != nil {
+		t.Fatalf("Failed to marshal: %v", err)
+	}
+
+	var exportedCfg CaddyConfig
+	if err := json.Unmarshal(exportedJSON, &exportedCfg); err != nil {
+		t.Fatalf("Failed to unmarshal: %v", err)
+	}
+
+	server := exportedCfg.Apps.HTTP.Servers["srv0"]
+	if len(server.Routes) != 1 {
+		t.Fatalf("Expected 1 exported route, got %d", len(server.Routes))
+	}
+
+	exportedRoute := server.Routes[0]
+	// The subroute should be preserved (not stripped)
+	if len(exportedRoute.Handle) == 0 {
+		t.Fatal("Expected handlers to be preserved for unknown subroute route")
+	}
+
+	handlerType, _ := exportedRoute.Handle[0]["handler"].(string)
+	if handlerType != "subroute" {
+		t.Errorf("Expected preserved subroute handler, got %s", handlerType)
+	}
+}
+
+func TestRoundTrip_TrivialSubrouteEditable(t *testing.T) {
+	// A trivial subroute with only managed handlers should be fully editable:
+	// RawCaddyRoute is cleared, so edits to upstreams/headers take effect on export.
+	raw := []byte(`{
+		"apps": {
+			"http": {
+				"servers": {
+					"srv0": {
+						"listen": [":443"],
+						"routes": [
+							{
+								"match": [{"host": ["app.example.com"]}],
+								"handle": [{
+									"handler": "subroute",
+									"routes": [{
+										"handle": [{
+											"handler": "reverse_proxy",
+											"upstreams": [{"dial": "localhost:3000"}]
+										}]
+									}]
+								}],
+								"terminal": true
+							}
+						]
+					}
+				}
+			}
+		}
+	}`)
+
+	var cfg CaddyConfig
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("Failed to unmarshal: %v", err)
+	}
+
+	routes, err := ParseCaddyConfig(&cfg)
+	if err != nil {
+		t.Fatalf("Failed to parse: %v", err)
+	}
+
+	imported := routes[0]
+	if imported.HandlerType != "reverse_proxy" {
+		t.Fatalf("Expected reverse_proxy, got %s", imported.HandlerType)
+	}
+	// RawCaddyRoute should be cleared for fully-managed subroute
+	if len(imported.RawCaddyRoute) != 0 {
+		t.Error("Expected RawCaddyRoute to be cleared for trivial subroute (fully editable)")
+	}
+
+	// Simulate user editing upstreams
+	imported.Config = json.RawMessage(`{"upstreams":["localhost:9999"]}`)
+
+	// Export — should use normal buildRoute (not buildRouteMerged) since RawCaddyRoute is nil
+	exportedConfig := BuildCaddyConfig(routes, nil)
+	exportedJSON, _ := json.Marshal(exportedConfig)
+	var exportedCfg CaddyConfig
+	json.Unmarshal(exportedJSON, &exportedCfg)
+
+	server := exportedCfg.Apps.HTTP.Servers["srv0"]
+	exportedRoute := server.Routes[0]
+
+	// Should be a flat reverse_proxy handler (not subroute), with the edited upstream
+	if len(exportedRoute.Handle) != 1 {
+		t.Fatalf("Expected 1 handler, got %d", len(exportedRoute.Handle))
+	}
+	handlerType, _ := exportedRoute.Handle[0]["handler"].(string)
+	if handlerType != "reverse_proxy" {
+		t.Errorf("Expected flat reverse_proxy, got %s", handlerType)
+	}
+	upstreams, _ := exportedRoute.Handle[0]["upstreams"].([]any)
+	if len(upstreams) != 1 {
+		t.Fatalf("Expected 1 upstream, got %d", len(upstreams))
+	}
+	upstream, _ := upstreams[0].(map[string]any)
+	if dial, _ := upstream["dial"].(string); dial != "localhost:9999" {
+		t.Errorf("Expected edited upstream localhost:9999, got %s", dial)
+	}
+}
+
+func TestRoundTrip_SubrouteImport(t *testing.T) {
+	// Simulate importing a subroute-wrapped route with unmanaged middleware (crowdsec),
+	// then exporting it. The export should preserve the subroute structure, not duplicate handlers.
+	raw := []byte(`{
+		"apps": {
+			"http": {
+				"servers": {
+					"srv0": {
+						"listen": [":443"],
+						"routes": [
+							{
+								"match": [{"host": ["app.example.com"]}],
+								"handle": [{
+									"handler": "subroute",
+									"routes": [{
+										"handle": [
+											{"handler": "crowdsec"},
+											{
+												"handler": "reverse_proxy",
+												"upstreams": [{"dial": "localhost:3000"}]
+											}
+										]
+									}]
+								}],
+								"terminal": true
+							}
+						]
+					}
+				}
+			}
+		}
+	}`)
+
+	var cfg CaddyConfig
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("Failed to unmarshal: %v", err)
+	}
+
+	// Import
+	routes, err := ParseCaddyConfig(&cfg)
+	if err != nil {
+		t.Fatalf("Failed to parse: %v", err)
+	}
+	if len(routes) != 1 {
+		t.Fatalf("Expected 1 route, got %d", len(routes))
+	}
+
+	imported := routes[0]
+	if imported.HandlerType != "reverse_proxy" {
+		t.Fatalf("Expected reverse_proxy, got %s", imported.HandlerType)
+	}
+
+	// Export (rebuild)
+	exportedConfig := BuildCaddyConfig(routes, nil)
+
+	// Serialize and re-parse to verify clean round-trip
+	exportedJSON, err := json.Marshal(exportedConfig)
+	if err != nil {
+		t.Fatalf("Failed to marshal exported config: %v", err)
+	}
+
+	var exportedCfg CaddyConfig
+	if err := json.Unmarshal(exportedJSON, &exportedCfg); err != nil {
+		t.Fatalf("Failed to unmarshal exported config: %v", err)
+	}
+
+	server := exportedCfg.Apps.HTTP.Servers["srv0"]
+	if len(server.Routes) != 1 {
+		t.Fatalf("Expected 1 exported route, got %d", len(server.Routes))
+	}
+
+	exportedRoute := server.Routes[0]
+	// Should preserve the subroute handler, NOT add a duplicate reverse_proxy
+	if len(exportedRoute.Handle) != 1 {
+		t.Errorf("Expected 1 top-level handler (subroute), got %d (possible handler duplication)", len(exportedRoute.Handle))
+	}
+
+	handlerType, _ := exportedRoute.Handle[0]["handler"].(string)
+	if handlerType != "subroute" {
+		t.Errorf("Expected subroute handler preserved, got %s", handlerType)
+	}
+}

--- a/internal/config/parser_test.go
+++ b/internal/config/parser_test.go
@@ -797,6 +797,10 @@ func TestParseCaddyConfig_RealCaddyfileStructure(t *testing.T) {
 	if len(rpCfg.Upstreams) != 1 || rpCfg.Upstreams[0] != "docker-hp:2111" {
 		t.Errorf("Expected upstreams [docker-hp:2111], got %v", rpCfg.Upstreams)
 	}
+	// Route has unmanaged middleware (crowdsec, appsec), should be read-only
+	if !route.ReadOnly {
+		t.Error("Expected ReadOnly to be true for route with unmanaged middleware")
+	}
 }
 
 func TestParseCaddyConfig_NestedSubroutes(t *testing.T) {
@@ -915,6 +919,10 @@ func TestParseCaddyConfig_SubrouteWithMatchers(t *testing.T) {
 	if len(route.RawCaddyRoute) == 0 {
 		t.Error("Expected RawCaddyRoute to be preserved")
 	}
+	// Complex subroute should be read-only
+	if !route.ReadOnly {
+		t.Error("Expected ReadOnly to be true for complex subroute with matchers")
+	}
 }
 
 func TestParseCaddyConfig_SubrouteWithUnmanagedHandler(t *testing.T) {
@@ -972,6 +980,10 @@ func TestParseCaddyConfig_SubrouteWithUnmanagedHandler(t *testing.T) {
 	// RawCaddyRoute should preserve the full original including crowdsec
 	if len(route.RawCaddyRoute) == 0 {
 		t.Error("Expected RawCaddyRoute to be preserved")
+	}
+	// Route has unmanaged middleware (crowdsec), should be read-only
+	if !route.ReadOnly {
+		t.Error("Expected ReadOnly to be true for route with unmanaged middleware")
 	}
 }
 
@@ -1164,6 +1176,10 @@ func TestRoundTrip_TrivialSubrouteEditable(t *testing.T) {
 	if len(imported.RawCaddyRoute) != 0 {
 		t.Error("Expected RawCaddyRoute to be cleared for trivial subroute (fully editable)")
 	}
+	// Trivial subroute with all managed handlers should NOT be read-only
+	if imported.ReadOnly {
+		t.Error("Expected ReadOnly to be false for trivial subroute (fully editable)")
+	}
 
 	// Simulate user editing upstreams
 	imported.Config = json.RawMessage(`{"upstreams":["localhost:9999"]}`)
@@ -1275,5 +1291,163 @@ func TestRoundTrip_SubrouteImport(t *testing.T) {
 	handlerType, _ := exportedRoute.Handle[0]["handler"].(string)
 	if handlerType != "subroute" {
 		t.Errorf("Expected subroute handler preserved, got %s", handlerType)
+	}
+}
+
+func TestParseCaddyConfig_SubrouteNonRedirectStaticResponse(t *testing.T) {
+	// A static_response without a Location header (e.g. error page, websocket blocker)
+	// should NOT be labeled "redir" — it should be "unknown" since we can't represent it.
+	cfg := &CaddyConfig{
+		Apps: &Apps{
+			HTTP: &HTTPApp{
+				Servers: map[string]*Server{
+					"srv0": {
+						Listen: []string{":443"},
+						Routes: []Route{
+							{
+								Match: []Match{
+									{Host: []string{"example.com"}},
+								},
+								Handle: []Handler{
+									{
+										"handler": "subroute",
+										"routes": []any{
+											map[string]any{
+												"match": []any{
+													map[string]any{
+														"path": []any{"/blocked"},
+													},
+												},
+												"handle": []any{
+													map[string]any{
+														"handler":     "static_response",
+														"status_code": float64(403),
+														"body":        "Forbidden",
+													},
+												},
+											},
+										},
+									},
+								},
+								Terminal: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	routes, err := ParseCaddyConfig(cfg)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	route := routes[0]
+	// Non-redirect static_response should be "unknown", not "redir"
+	if route.HandlerType == "redir" {
+		t.Errorf("Non-redirect static_response should not be labeled 'redir', got %s", route.HandlerType)
+	}
+	if route.HandlerType != "unknown" {
+		t.Errorf("Expected handler_type 'unknown' for non-redirect static_response, got %s", route.HandlerType)
+	}
+}
+
+func TestParseCaddyConfig_SubrouteRedirectStaticResponse(t *testing.T) {
+	// A static_response WITH a Location header should be detected as "redir" via deep search.
+	cfg := &CaddyConfig{
+		Apps: &Apps{
+			HTTP: &HTTPApp{
+				Servers: map[string]*Server{
+					"srv0": {
+						Listen: []string{":443"},
+						Routes: []Route{
+							{
+								Match: []Match{
+									{Host: []string{"old.example.com"}},
+								},
+								Handle: []Handler{
+									{
+										"handler": "subroute",
+										"routes": []any{
+											map[string]any{
+												"match": []any{
+													map[string]any{
+														"path": []any{"/*"},
+													},
+												},
+												"handle": []any{
+													map[string]any{
+														"handler":     "static_response",
+														"status_code": float64(301),
+														"headers": map[string]any{
+															"Location": []any{"https://new.example.com{http.request.uri}"},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								Terminal: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	routes, err := ParseCaddyConfig(cfg)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	route := routes[0]
+	if route.HandlerType != "redir" {
+		t.Errorf("Expected handler_type 'redir' for redirect static_response, got %s", route.HandlerType)
+	}
+}
+
+func TestParseCaddyConfig_SubrouteEmptyHandlers(t *testing.T) {
+	// Subroute with an inner route that has no handlers — should fall through to unknown.
+	cfg := &CaddyConfig{
+		Apps: &Apps{
+			HTTP: &HTTPApp{
+				Servers: map[string]*Server{
+					"srv0": {
+						Listen: []string{":443"},
+						Routes: []Route{
+							{
+								Match: []Match{
+									{Host: []string{"example.com"}},
+								},
+								Handle: []Handler{
+									{
+										"handler": "subroute",
+										"routes": []any{
+											map[string]any{
+												"handle": []any{},
+											},
+										},
+									},
+								},
+								Terminal: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	routes, err := ParseCaddyConfig(cfg)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	route := routes[0]
+	if route.HandlerType != "unknown" {
+		t.Errorf("Expected handler_type 'unknown' for empty subroute, got %s", route.HandlerType)
 	}
 }

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -18,6 +18,12 @@ type Route struct {
 	CreatedAt       time.Time       `json:"created_at"`
 	UpdatedAt       time.Time       `json:"updated_at"`
 
+	// ReadOnly indicates that this route contains handlers we can't fully represent
+	// (e.g. subroutes with unmanaged middleware). The route type is detected for display,
+	// but handler-level edits (upstreams, headers, etc.) won't take effect on export.
+	// Domain/path edits and enable/disable still work.
+	ReadOnly bool `json:"readonly,omitempty"`
+
 	// RawCaddyRoute stores the original Caddy route JSON for preserving
 	// unsupported handlers during round-trip sync.
 	// It is not exposed in JSON responses by default (unless requested, but here we hide it).

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -167,6 +167,7 @@ func (s *SQLiteStorage) scanRoute(row *sql.Row) (*Route, error) {
 		route.RawCaddyRoute = json.RawMessage(rawCaddyRoute)
 	}
 	route.StripPathPrefix = stripPathPrefix
+	route.ReadOnly = len(route.RawCaddyRoute) > 0
 	return &route, nil
 }
 
@@ -190,6 +191,7 @@ func (s *SQLiteStorage) scanRouteRows(rows *sql.Rows) (*Route, error) {
 		route.RawCaddyRoute = json.RawMessage(rawCaddyRoute)
 	}
 	route.StripPathPrefix = stripPathPrefix
+	route.ReadOnly = len(route.RawCaddyRoute) > 0
 	return &route, nil
 }
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -81,6 +81,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1800,6 +1801,7 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -2182,6 +2184,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2500,6 +2503,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3143,6 +3147,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3630,6 +3635,7 @@
       "integrity": "sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
@@ -4178,6 +4184,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4809,6 +4816,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4957,6 +4965,7 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.3.tgz",
       "integrity": "sha512-tCmoRkPQLpBeWzpmbhryairGnhW9tKV6c6gr/w+RhoRoKEJwsjzipwp//1oCpGPOchvSLaAPlpcJi9MwMmoPyA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -5166,6 +5175,7 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -5697,6 +5707,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5790,6 +5801,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -5883,6 +5895,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -6117,6 +6130,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -17,6 +17,7 @@ export interface Route {
   config: any;
   headers?: HeaderConfig;
   enabled: boolean;
+  readonly?: boolean;
   created_at: string;
   updated_at: string;
 }

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -67,6 +67,11 @@ function RouteCard({ route, onToggle, onDelete }: {
             <span class="bg-slate-700 px-2 py-0.5 rounded">
               {HANDLER_LABELS[route.handler_type] || route.handler_type}
             </span>
+            {route.readonly && (
+              <span class="bg-amber-600/30 text-amber-300 text-xs px-1.5 py-0.5 rounded" title="Imported route with unmanaged middleware. Handler config is read-only.">
+                imported
+              </span>
+            )}
             <span class="truncate">{getConfigSummary()}</span>
           </div>
 

--- a/web/src/pages/RouteForm.tsx
+++ b/web/src/pages/RouteForm.tsx
@@ -26,6 +26,7 @@ export function RouteForm({ id }: RouteFormProps) {
   const [config, setConfig] = useState<any>({ upstreams: [], websocket: false, headers: {}, load_balancing: 'round_robin' });
   const [headers, setHeaders] = useState(getDefaultHeaderConfig());
   const [showHeaders, setShowHeaders] = useState(false);
+  const [readOnly, setReadOnly] = useState(false);
 
   useEffect(() => {
     if (isEdit) {
@@ -41,6 +42,7 @@ export function RouteForm({ id }: RouteFormProps) {
       setStripPathPrefix(route.strip_path_prefix || '');
       setHandlerType(route.handler_type);
       setConfig(typeof route.config === 'string' ? JSON.parse(route.config) : route.config);
+      setReadOnly(route.readonly || false);
       if (route.headers) {
         setHeaders(route.headers);
       }
@@ -116,6 +118,12 @@ export function RouteForm({ id }: RouteFormProps) {
         </div>
       )}
 
+      {readOnly && (
+        <div class="bg-amber-900/50 border border-amber-700 rounded-lg p-4 mb-6 text-amber-300">
+          This route was imported with unmanaged middleware (e.g. crowdsec, appsec) and its handler configuration is read-only. You can still edit the domain, path, and enable/disable the route.
+        </div>
+      )}
+
       <form onSubmit={handleSubmit} class="space-y-8">
         {/* Domain & Path */}
         <div class="card">
@@ -185,7 +193,7 @@ export function RouteForm({ id }: RouteFormProps) {
         </div>
 
         {/* Handler Type Selection */}
-        <div class="card">
+        <div class={readOnly ? 'card opacity-60 pointer-events-none' : 'card'}>
           <h2 class="text-lg font-semibold mb-4">Handler Type</h2>
           <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
             {HANDLER_TYPES.map((type) => (
@@ -198,6 +206,7 @@ export function RouteForm({ id }: RouteFormProps) {
                     ? 'ring-2 ring-primary-500 border-primary-500'
                     : 'hover:border-slate-600'
                 }`}
+                disabled={readOnly}
               >
                 <div class="text-2xl mb-2">{type.icon}</div>
                 <div class="font-medium">{type.name}</div>
@@ -208,17 +217,17 @@ export function RouteForm({ id }: RouteFormProps) {
         </div>
 
         {/* Handler-specific config */}
-        <div class="card">
+        <div class={readOnly ? 'card opacity-60 pointer-events-none' : 'card'}>
           <h2 class="text-lg font-semibold mb-4">Handler Configuration</h2>
-          
+
           {handlerType === 'reverse_proxy' && (
             <ReverseProxyConfig config={config} onChange={setConfig} />
           )}
-          
+
           {handlerType === 'file_server' && (
             <FileServerConfig config={config} onChange={setConfig} />
           )}
-          
+
           {handlerType === 'redir' && (
             <RedirectConfig config={config} onChange={setConfig} />
           )}


### PR DESCRIPTION
## Summary
- Routes imported from Caddyfile-configured Caddy instances now correctly detect handler types instead of showing "unknown"
- Handles three levels of subroute complexity: trivial (fully editable), middleware-wrapped (type detected, structure preserved), and complex (deep type detection)
- Tested against production instance: 27/27 routes correctly identified (was 0/27)

## Changed files
- `internal/config/parser.go` — subroute flattening, deep type detection, managed-handler check
- `internal/config/builder.go` — preserve subroute structure for routes with unmanaged middleware
- `internal/config/parser_test.go` — 12 new tests covering all subroute variants

## Test plan
- [x] All existing tests pass (46 total including 12 new)
- [x] Verified against real Caddy instance with 27 Caddyfile-configured routes
- [x] Trivial subroutes remain editable (RawCaddyRoute cleared)
- [x] Complex subroutes preserved for safe round-trip export
- [x] Deep detection prioritizes reverse_proxy > file_server > static_response